### PR TITLE
Add support for asahi-linux (mac)

### DIFF
--- a/install/config/hardware/network.sh
+++ b/install/config/hardware/network.sh
@@ -8,7 +8,7 @@ DHCP=yes
 EOF
 sudo tee /etc/systemd/network/25-wifi.network >/dev/null <<'EOF'
 [Match]
-Name=wlan*
+Name=wl*
 
 [Network]
 DHCP=yes

--- a/install/packaging/base.sh
+++ b/install/packaging/base.sh
@@ -1,5 +1,12 @@
 # Install base groups
 mapfile -t groups < <(grep -v '^#' "$OMADORA_INSTALL/omadora-base.groups" | grep -v '^$')
+
+# Exclude hardware-support group on Asahi Linux
+# (tries to install nvidia-gpu)
+if grep -q 'asahi' /etc/os-release 2>/dev/null || uname -r | grep -q 'asahi'; then
+    groups=("${groups[@]/hardware-support/}")
+fi
+
 sudo dnf group install -y "${groups[@]}"
 
 # Install base packages

--- a/install/preflight/guard.sh
+++ b/install/preflight/guard.sh
@@ -15,8 +15,8 @@ abort() {
 # Must not be running as root
 [ "$EUID" -eq 0 ] && abort "Running as user (not root)"
 
-# Must be x86 only to fully work
-[ "$(uname -m)" != "x86_64" ] && abort "x86_64 CPU"
+# x86_64 or ARM64 (mac)
+[ "$(uname -m)" == "x86_64" || "$(uname -m)" == "aarch64" ] || abort "x86_64 CPU"
 
 # Should be a core only install
 groups=$(dnf group list --installed --hidden -q | awk 'NR>1 {print $1}')


### PR DESCRIPTION
- On mac wifi cards look like: wlp1s0f0
- Fedora hardware-support package group tries to install nvidia-gpu and fails