### PR TITLE
restore gtk3 adwaita dark

### DIFF
--- a/install/omadora-base.packages
+++ b/install/omadora-base.packages
@@ -1,3 +1,4 @@
+adw-gtk3-theme
 adwaita-sans-fonts
 alacritty
 bash-color-prompt

--- a/install/packaging/flatpak.sh
+++ b/install/packaging/flatpak.sh
@@ -4,6 +4,8 @@ sudo flatpak remote-add --system --if-not-exists flathub https://dl.flathub.org/
 # Install default flatpaks
 sudo flatpak install --system --noninteractive -y flathub com.dec05eba.gpu_screen_recorder
 sudo flatpak install --system --noninteractive -y flathub org.localsend.localsend_app
+sudo flatpak install --system --noninteractive -y flathub org.gtk.Gtk3theme.adw-gtk3
+sudo flatpak install --system --noninteractive -y flathub org.gtk.Gtk3theme.adw-gtk3-dark
 
 # Add flatpak overrides
 flatpak override --user --filesystem=home --filesystem=/tmp/localsend org.localsend.localsend_app

--- a/lib/theme.sh
+++ b/lib/theme.sh
@@ -128,12 +128,13 @@ theme_set_gnome() {
   local light_mode_file="${OMADORA_CURRENT_THEME_DIR}/light.mode"
   local icons_file="${OMADORA_CURRENT_THEME_DIR}/icons.theme"
 
-  local gtk_theme="Adwaita"
+  local gtk_theme="adw-gtk3-dark"
   local icon_theme="Yaru-blue"
   local color_scheme="prefer-dark"
 
   if [[ -f "$light_mode_file" ]]; then
     color_scheme="prefer-light"
+    gtk_theme="adw-gtk3"
   fi
 
   if [[ -f "$icons_file" ]]; then

--- a/migrations/1783461138.sh
+++ b/migrations/1783461138.sh
@@ -1,2 +1,8 @@
-echo "Install new gtk3 Adwaita theme..."
+echo "Install ported Adwaita gtk3 themes..."
+
 sudo dnf install -y adw-gtk3-theme
+
+sudo flatpak install --system --noninteractive -y flathub org.gtk.Gtk3theme.adw-gtk3
+sudo flatpak install --system --noninteractive -y flathub org.gtk.Gtk3theme.adw-gtk3-dark
+
+systemctl --user restart omadora-polkitagent.service

--- a/migrations/1783461138.sh
+++ b/migrations/1783461138.sh
@@ -1,0 +1,2 @@
+echo "Install new gtk3 Adwaita theme..."
+sudo dnf install -y adw-gtk3-theme


### PR DESCRIPTION
This would add the package adw-gtk3-theme which would restore the dark theme for gtk3 apps.